### PR TITLE
fixup: puppet environment used for catalog-diff should be the merge-request environment, not the source branch of the MR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,7 +99,7 @@ variables:
     - *create_csr_attributes_yaml
     - puppet ssl --confdir /tmp/.puppetlabs/etc/puppet submit_request --ca_server puppetserver --certificate_revocation=false
     - echo -e "section_end:`date +%s`:setup\r\e[0K"
-    - puppet catalog --confdir /tmp/.puppetlabs/etc/puppet --environmentpath /etc/puppetlabs/code/environments --environment ${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME} --certificate_revocation=false diff puppetserver:8140/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} puppetserver:8140/mr_${CI_MERGE_REQUEST_IID} ${DIFF_FLAGS} --output_report /catalog-diff/${REPORT}.json
+    - puppet catalog --confdir /tmp/.puppetlabs/etc/puppet --environmentpath /etc/puppetlabs/code/environments --environment mr_${CI_MERGE_REQUEST_IID} --certificate_revocation=false diff puppetserver:8140/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME} puppetserver:8140/mr_${CI_MERGE_REQUEST_IID} ${DIFF_FLAGS} --output_report /catalog-diff/${REPORT}.json
   after_script:
     - *cleanup_cert
     - echo "You can view the report details at ${PUPPETDIFF_URL}/?report=${REPORT}"


### PR DESCRIPTION
When starting Catalog-Diff, you expect it to run on the Environment that was deployed by the pipeline of the MergeRequest, not the environment that was created by the gitlab-ci pipeline triggered by the source branch of the MergeRequest.